### PR TITLE
Disclaimer deletion

### DIFF
--- a/accounts/management/commands/delete_expired_disclaimers.py
+++ b/accounts/management/commands/delete_expired_disclaimers.py
@@ -1,9 +1,5 @@
 '''
-Check for users who do not have a paid class or event booking within the past
-year.
-Delete both Print and Online disclaimers (there should only be one or the
-other, but check for both just in case)
-Email studio notification and note whether online or paper or both
+Delete all disclaimers signed or updated > 3 yrs ago
 ActivityLog it
 '''
 import logging
@@ -17,6 +13,8 @@ from django.template.loader import get_template
 from django.core.management.base import BaseCommand
 from django.db.models import Q
 
+from dateutil.relativedelta import relativedelta
+
 from accounts.models import OnlineDisclaimer, PrintDisclaimer
 from booking.email_helpers import send_support_email
 from activitylog.models import ActivityLog
@@ -26,32 +24,17 @@ logger = logging.getLogger(__name__)
 
 
 class Command(BaseCommand):
-    help = 'Delete disclaimers for users who do not have a paid booking ' \
-           'within the past year'
+    help = "Delete online disclaimers over 3 years old and print disclaimers " \
+           "for users who haven't booked in past year"
 
     def handle(self, *args, **options):
 
         # get relevant users
 
-        expire_date = timezone.now() - timedelta(days=365)
-
-        expired_users = []
-
-        for user in User.objects.all():
-            if not user.bookings.exists():
-                expired_users.append(user)
-            else:
-                recent_bookings = [
-                    True for booking in user.bookings.all()
-                    if (booking.event.date > expire_date) and booking.paid
-                    ]
-                if not recent_bookings:
-                    expired_users.append(user)
+        expire_date = timezone.now() - relativedelta(years=3)
 
         old_print_disclaimers_to_delete = PrintDisclaimer.objects\
-            .select_related('user').filter(
-            date__lt=expire_date, user__in=expired_users
-        )
+            .select_related('user').filter(date__lt=expire_date)
         print_disclaimer_users = [
             '{} {}'.format(disc.user.first_name, disc.user.last_name)
             for disc in old_print_disclaimers_to_delete
@@ -60,8 +43,7 @@ class Command(BaseCommand):
         old_online_disclaimers_to_delete = OnlineDisclaimer.objects\
             .select_related('user').filter(
             Q(date__lt=expire_date) &
-            (Q(date_updated__isnull=True) | Q(date_updated__lt=expire_date)) &
-            Q(user__in=expired_users)
+            (Q(date_updated__isnull=True) | Q(date_updated__lt=expire_date))
         )
         online_disclaimer_users = [
             '{} {}'.format(disc.user.first_name, disc.user.last_name)
@@ -72,13 +54,15 @@ class Command(BaseCommand):
 
         if print_disclaimer_users:
             ActivityLog.objects.create(
-                log='Print disclaimers deleted for expired users: {}'.format(
+                log='Print disclaimers more than 3 yrs old deleted for '
+                    'users: {}'.format(
                     ', '.join(print_disclaimer_users)
                 )
             )
         if online_disclaimer_users:
             ActivityLog.objects.create(
-                log='Online disclaimers deleted for expired users: {}'.format(
+                log='Online disclaimers more than 3 yrs old deleted for '
+                    'users: {}'.format(
                     ', '.join(online_disclaimer_users)
                 )
             )

--- a/accounts/management/commands/delete_expired_disclaimers.py
+++ b/accounts/management/commands/delete_expired_disclaimers.py
@@ -70,46 +70,19 @@ class Command(BaseCommand):
         old_print_disclaimers_to_delete.delete()
         old_online_disclaimers_to_delete.delete()
 
-        if print_disclaimer_users or online_disclaimer_users:
-            # email studio
-            ctx = {
-                'print_disclaimer_users': print_disclaimer_users,
-                'online_disclaimer_users': online_disclaimer_users
-            }
-
-            # send mail to studio
-            try:
-                send_mail('{} Disclaimers deleted for expired users'.format(
-                    settings.ACCOUNT_EMAIL_SUBJECT_PREFIX,
-                ),
-                    get_template(
-                        'account/email/delete_disclaimers.txt'
-                    ).render(ctx),
-                    settings.DEFAULT_FROM_EMAIL,
-                    [settings.DEFAULT_STUDIO_EMAIL],
-                    html_message=get_template(
-                        'account/email/delete_disclaimers.html'
-                        ).render(ctx),
-                    fail_silently=False)
-            except Exception as e:
-                # send mail to tech support with Exception
-                send_support_email(
-                    e, __name__, "Automatic disclaimer deletion - studio email"
+        if print_disclaimer_users:
+            ActivityLog.objects.create(
+                log='Print disclaimers deleted for expired users: {}'.format(
+                    ', '.join(print_disclaimer_users)
                 )
-
-            if print_disclaimer_users:
-                ActivityLog.objects.create(
-                    log='Print disclaimers deleted for expired users: {}'.format(
-                        ', '.join(print_disclaimer_users)
-                    )
+            )
+        if online_disclaimer_users:
+            ActivityLog.objects.create(
+                log='Online disclaimers deleted for expired users: {}'.format(
+                    ', '.join(online_disclaimer_users)
                 )
-            if online_disclaimer_users:
-                ActivityLog.objects.create(
-                    log='Online disclaimers deleted for expired users: {}'.format(
-                        ', '.join(online_disclaimer_users)
-                    )
-                )
-        else:
+            )
+        if not print_disclaimer_users or online_disclaimer_users:
             self.stdout.write('No disclaimers to delete')
             ActivityLog.objects.create(
                 log='Delete disclaimers job run; no expired users'

--- a/accounts/tests/test_management.py
+++ b/accounts/tests/test_management.py
@@ -178,28 +178,6 @@ class DeleteExpiredDisclaimersTests(PatchRequestMixin, TestCase):
         self.assertEqual(
             OnlineDisclaimer.objects.first().user, self.user_online_only
         )
-        
-    def test_email_sent_to_studio(self):
-        self.assertEqual(OnlineDisclaimer.objects.count(), 2)
-        self.assertEqual(PrintDisclaimer.objects.count(), 2)
-
-        # make one paid booking for self.user_online_only in past 365 days; this
-        # user's disclaimer should not be deleted
-        mommy.make_recipe(
-            'booking.booking',
-            user=self.user_online_only,
-            event__date=timezone.now()-timedelta(360),
-            paid=True
-        )
-        management.call_command('delete_expired_disclaimers')
-        self.assertEqual(len(mail.outbox), 1)
-
-    @patch('accounts.management.commands.delete_expired_disclaimers.send_mail')
-    def test_email_errors_sending_to_studio(self, mock_send_mail):
-        mock_send_mail.side_effect = Exception('Error sending mail')
-        management.call_command('delete_expired_disclaimers')
-        self.assertEqual(len(mail.outbox), 1)
-        self.assertEqual(mail.outbox[0].to, [settings.SUPPORT_EMAIL])
 
     @patch('accounts.management.commands.delete_expired_disclaimers.send_mail')
     @patch('booking.email_helpers.send_mail')

--- a/accounts/tests/test_management.py
+++ b/accounts/tests/test_management.py
@@ -15,7 +15,7 @@ from accounts.management.commands.import_disclaimer_data import logger as \
     import_disclaimer_data_logger
 from accounts.management.commands.export_encrypted_disclaimers import EmailMessage
 from accounts.models import PrintDisclaimer, OnlineDisclaimer
-
+from activitylog.models import ActivityLog
 from booking.models import Booking
 from common.tests.helpers import TestSetupMixin, PatchRequestMixin
 
@@ -28,28 +28,28 @@ class DeleteExpiredDisclaimersTests(PatchRequestMixin, TestCase):
             'booking.user', first_name='Test', last_name='User')
         mommy.make(
             OnlineDisclaimer, user=self.user_online_only,
-            date=timezone.now()-timedelta(370)
+            date=timezone.now()-timedelta(1100) # > 3 yrs
         )
         self.user_print_only = mommy.make_recipe(
             'booking.user', first_name='Test', last_name='User1'
         )
         mommy.make(
             PrintDisclaimer, user=self.user_print_only,
-            date=timezone.now()-timedelta(370)
+            date=timezone.now()-timedelta(1100) # > 3 yrs
         )
         self.user_both = mommy.make_recipe(
             'booking.user', first_name='Test', last_name='User2'
         )
         mommy.make(
             OnlineDisclaimer, user=self.user_both,
-            date=timezone.now()-timedelta(370)
+            date=timezone.now()-timedelta(1100) # > 3 yrs
         )
         mommy.make(
             PrintDisclaimer, user=self.user_both,
-            date=timezone.now()-timedelta(370)
+            date=timezone.now()-timedelta(1100) # > 3 yrs
         )
 
-    def test_disclaimers_deleted_if_no_bookings_in_past_year(self):
+    def test_disclaimers_deleted_if_more_than_3_years_old(self):
         self.assertEqual(OnlineDisclaimer.objects.count(), 2)
         self.assertEqual(PrintDisclaimer.objects.count(), 2)
 
@@ -57,58 +57,32 @@ class DeleteExpiredDisclaimersTests(PatchRequestMixin, TestCase):
         self.assertEqual(OnlineDisclaimer.objects.count(), 0)
         self.assertEqual(PrintDisclaimer.objects.count(), 0)
 
-    def test_disclaimers_deleted_if_no_paid_booking_in_past_year(self):
-        self.assertEqual(OnlineDisclaimer.objects.count(), 2)
-        self.assertEqual(PrintDisclaimer.objects.count(), 2)
+        activitylogs = ActivityLog.objects.values_list('log', flat=True)
+        print_users = [
+            '{} {}'.format(user.first_name, user.last_name)
+            for user in [self.user_print_only, self.user_both]
+        ]
 
-        # make one paid booking for self.user_online_only in past 365 days; this
-        # user's disclaimer should not be deleted
-        mommy.make_recipe(
-            'booking.booking',
-            user=self.user_online_only,
-            event__date=timezone.now()-timedelta(360),
-            paid=True
-        )
-        management.call_command('delete_expired_disclaimers')
-        self.assertEqual(OnlineDisclaimer.objects.count(), 1)
-        self.assertEqual(PrintDisclaimer.objects.count(), 0)
-        self.assertEqual(
-            OnlineDisclaimer.objects.first().user, self.user_online_only
+        self.assertIn(
+            'Print disclaimers more than 3 yrs old deleted for users: {}'.format(
+                ', '.join(print_users)
+            ),
+            activitylogs
         )
 
-    def test_disclaimers_deleted_if_only_unpaid_booking_in_past_year(self):
-        self.assertEqual(OnlineDisclaimer.objects.count(), 2)
-        self.assertEqual(PrintDisclaimer.objects.count(), 2)
+        online_users = [
+            '{} {}'.format(user.first_name, user.last_name)
+            for user in [self.user_online_only, self.user_both]
+        ]
 
-        # make one unpaid booking for self.user_online_only in past 365 days; this
-        # user's disclaimer should still be deleted because unpaid
-        mommy.make_recipe(
-            'booking.booking',
-            user=self.user_online_only,
-            event__date=timezone.now()-timedelta(360),
-            paid=False
+        self.assertIn(
+            'Online disclaimers more than 3 yrs old deleted for users: {}'.format(
+                ', '.join(online_users)
+            ),
+            activitylogs
         )
-        management.call_command('delete_expired_disclaimers')
-        self.assertEqual(OnlineDisclaimer.objects.count(), 0)
-        self.assertEqual(PrintDisclaimer.objects.count(), 0)
 
-    def test_both_print_and_online_disclaimers_deleted(self):
-        self.assertEqual(OnlineDisclaimer.objects.count(), 2)
-        self.assertEqual(PrintDisclaimer.objects.count(), 2)
-
-        # make one paid booking for self.user_both in past 365 days; both other
-        # disclaimers should be deleted because unpaid
-        mommy.make_recipe(
-            'booking.booking',
-            user=self.user_both,
-            event__date=timezone.now()-timedelta(360),
-            paid=True
-        )
-        management.call_command('delete_expired_disclaimers')
-        self.assertEqual(OnlineDisclaimer.objects.count(), 1)
-        self.assertEqual(PrintDisclaimer.objects.count(), 1)
-
-    def test_disclaimers_not_deleted_if_created_in_past_year(self):
+    def test_disclaimers_not_deleted_if_created_in_past_3_years(self):
         # make a user with a disclaimer created today
         user = mommy.make_recipe('booking.user')
         mommy.make(OnlineDisclaimer, user=user)
@@ -116,98 +90,25 @@ class DeleteExpiredDisclaimersTests(PatchRequestMixin, TestCase):
         self.assertEqual(OnlineDisclaimer.objects.count(), 3)
         self.assertEqual(PrintDisclaimer.objects.count(), 2)
 
-        # user has no bookings in past 365 days, but disclaimer should not be
-        # deleted because it was created < 365 days ago.  All others will be.
+        # disclaimer should not be deleted because it was created < 3 yrs ago.
+        # All others will be.
         management.call_command('delete_expired_disclaimers')
         self.assertEqual(OnlineDisclaimer.objects.count(), 1)
         self.assertEqual(PrintDisclaimer.objects.count(), 0)
 
-    def test_disclaimers_not_deleted_if_updated_in_past_year(self):
+    def test_disclaimers_not_deleted_if_updated_in_past_3_years(self):
         # make a user with a disclaimer created > yr ago but updated in past yr
         user = mommy.make_recipe('booking.user')
         mommy.make(
-            OnlineDisclaimer, user=user, date=timezone.now() - timedelta(370),
-            date_updated=timezone.now() - timedelta(360),
+            OnlineDisclaimer, user=user, date=timezone.now() - timedelta(1100),
+            date_updated=timezone.now() - timedelta(1090),
         )
         self.assertEqual(OnlineDisclaimer.objects.count(), 3)
         self.assertEqual(PrintDisclaimer.objects.count(), 2)
 
-        # user has no bookings in past 365 days, but disclaimer should not be
-        # deleted because it was created < 365 days ago.  The other 3 will be
-        # deleted
-
         management.call_command('delete_expired_disclaimers')
         self.assertEqual(OnlineDisclaimer.objects.count(), 1)
         self.assertEqual(PrintDisclaimer.objects.count(), 0)
-
-    def test_disclaimer_with_multiple_bookings(self):
-        self.assertEqual(OnlineDisclaimer.objects.count(), 2)
-        self.assertEqual(PrintDisclaimer.objects.count(), 2)
-
-        # make paid and unpaid bookings for self.user_online_only in past 365
-        # days and earlier; disclaimer not deleted
-        mommy.make_recipe(
-            'booking.booking',
-            user=self.user_online_only,
-            event__date=timezone.now()-timedelta(360),
-            paid=True
-        )
-        mommy.make_recipe(
-            'booking.booking',
-            user=self.user_online_only,
-            event__date=timezone.now()-timedelta(200),
-            paid=False
-        )
-        mommy.make_recipe(
-            'booking.booking',
-            user=self.user_online_only,
-            event__date=timezone.now()-timedelta(400),
-            paid=True
-        )
-        mommy.make_recipe(
-            'booking.booking',
-            user=self.user_online_only,
-            event__date=timezone.now()-timedelta(400),
-            paid=False
-        )
-
-        management.call_command('delete_expired_disclaimers')
-        # only disclaimer for self.user_online_only is not deleted
-        self.assertEqual(OnlineDisclaimer.objects.count(), 1)
-        self.assertEqual(PrintDisclaimer.objects.count(), 0)
-        self.assertEqual(
-            OnlineDisclaimer.objects.first().user, self.user_online_only
-        )
-
-    @patch('accounts.management.commands.delete_expired_disclaimers.send_mail')
-    @patch('booking.email_helpers.send_mail')
-    def test_email_errors(self, mock_send_mail, mock_send_mail1):
-        mock_send_mail.side_effect = Exception('Error sending mail')
-        mock_send_mail1.side_effect = Exception('Error sending mail')
-        self.assertEqual(OnlineDisclaimer.objects.count(), 2)
-        self.assertEqual(PrintDisclaimer.objects.count(), 2)
-
-        management.call_command('delete_expired_disclaimers')
-        self.assertEqual(len(mail.outbox), 0)
-        self.assertEqual(OnlineDisclaimer.objects.count(), 0)
-        self.assertEqual(PrintDisclaimer.objects.count(), 0)
-
-    def test_email_not_sent_to_studio_if_nothing_deleted(self):
-        self.assertEqual(OnlineDisclaimer.objects.count(), 2)
-        self.assertEqual(PrintDisclaimer.objects.count(), 2)
-
-        for user in User.objects.all():
-            mommy.make_recipe(
-            'booking.booking',
-            user=user,
-            event__date=timezone.now()-timedelta(10),
-            paid=True
-        )
-
-        management.call_command('delete_expired_disclaimers')
-        self.assertEqual(OnlineDisclaimer.objects.count(), 2)
-        self.assertEqual(PrintDisclaimer.objects.count(), 2)
-        self.assertEqual(len(mail.outbox), 0)
 
 
 @override_settings(LOG_FOLDER=os.path.dirname(__file__))


### PR DESCRIPTION
Stop sending studio emails for deleted disclaimers.
Update to delete any > 3yrs old, irrespective of bookings
Fixes #74 and #75 